### PR TITLE
Update vault policy name - it is no longer specific to publishing / web.

### DIFF
--- a/dp-import-api.nomad
+++ b/dp-import-api.nomad
@@ -29,6 +29,7 @@ job "dp-import-api" {
 
       service {
         name = "dp-import-api"
+        port = "http"
         tags = ["publishing"]
       }
 

--- a/dp-import-api.nomad
+++ b/dp-import-api.nomad
@@ -47,7 +47,7 @@ job "dp-import-api" {
       }
 
       vault {
-        policies = ["dp-import-api-publishing"]
+        policies = ["dp-import-api"]
       }
     }
   }


### PR DESCRIPTION
### What

Update vault policy name - it is no longer specific to publishing / web. 
