### PR TITLE
bugfix: close idle connections when retrieving rows from postgres

### DIFF
--- a/api/datastore.go
+++ b/api/datastore.go
@@ -17,7 +17,7 @@ type DataStore interface {
 	AddEvent(instanceID string, event *models.Event) error
 	AddDimension(instanceID string, dimension *models.Dimension) error
 	GetDimensions(instanceID string) ([]models.Dimension, error)
-	GetDimensionValues(instanceID, dimensionName string) (models.UniqueDimensionValues, error)
+	GetDimensionValues(instanceID, dimensionName string) (*models.UniqueDimensionValues, error)
 	AddNodeID(instanceID string, dimension *models.Dimension) error
 	UpdateObservationCount(instanceID string, count int) error
 	PrepareImportJob(jobID string) (*models.ImportData, error)

--- a/mocks/datastore/datastore.go
+++ b/mocks/datastore/datastore.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"errors"
+
 	"github.com/ONSdigital/dp-import-api/api-errors"
 	"github.com/ONSdigital/dp-import-api/models"
 )
@@ -125,14 +126,14 @@ func (ds *DataStore) GetDimensions(instanceID string) ([]models.Dimension, error
 	return []models.Dimension{models.Dimension{Name: "1234-geography.newport", Value: "newport", NodeID: "234234234"}}, nil
 }
 
-func (ds *DataStore) GetDimensionValues(instanceID, dimensionName string) (models.UniqueDimensionValues, error) {
+func (ds *DataStore) GetDimensionValues(instanceID, dimensionName string) (*models.UniqueDimensionValues, error) {
 	if ds.NotFound {
-		return models.UniqueDimensionValues{}, api_errors.JobNotFoundError
+		return nil, api_errors.JobNotFoundError
 	}
 	if ds.InternalError {
-		return models.UniqueDimensionValues{}, internalError
+		return nil, internalError
 	}
-	return models.UniqueDimensionValues{Name: dimensionName, Values: []string{"123", "321"}}, nil
+	return &models.UniqueDimensionValues{Name: dimensionName, Values: []string{"123", "321"}}, nil
 }
 
 func (ds *DataStore) AddNodeID(instanceID string, dimension *models.Dimension) error {


### PR DESCRIPTION
### What

Handle idle connections when retrieving rows from postgres table by closing the connection once method completes.

Also handle any row errors, for instance end of reader error.

### How to review

Make sure tests still pass. All methods using pq Query method defers closing the connection to postgres using: `defer row.Close()`. See doc here: https://golang.org/pkg/database/sql/#DB.Query

### Who can review

Team B
