### PR TITLE
fix to nomad build - no need to copy plan to build/ for concourse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ export GOARCH?=$(shell go env GOARCH)
 build:
 	@mkdir -p $(BUILD_ARCH)/$(BIN_DIR)
 	go build -o $(BUILD_ARCH)/$(BIN_DIR)/$(MAIN) cmd/$(MAIN)/main.go
-	cp $(MAIN).nomad $(BUILD_ARCH)/
 debug:
 	HUMAN_LOG=1 go run cmd/$(MAIN)/main.go
 


### PR DESCRIPTION
@CarlHembrough - you were right, Lloyd confirmed:

I think the problem was that I had a more uptodate `develop`
than concourse was building (because I had merged via github!!) 👎  👎 
The commit I was looking at was github-unverified,
and concourse wouldn't touch that commit with a bargepole.

So, the repo built by concourse didn't have the `*.nomad` file at all.
Thus the concourse/nomad step didn't have a file to copy from the repo.

Two lessons:
- merge on the command line
- pay attention to the commit that concourse has built
