### PR TITLE
Fix to use errors package from the standard library instead of external

### DIFF
--- a/job/service.go
+++ b/job/service.go
@@ -1,11 +1,11 @@
 package job
 
 import (
+	"errors"
 	"github.com/ONSdigital/dp-import-api/datastore"
 	"github.com/ONSdigital/dp-import-api/models"
 	"github.com/ONSdigital/dp-import-api/url"
 	"github.com/ONSdigital/go-ns/log"
-	"github.com/pkg/errors"
 	"github.com/satori/go.uuid"
 )
 

--- a/job/service_test.go
+++ b/job/service_test.go
@@ -1,12 +1,12 @@
 package job_test
 
 import (
+	"errors"
 	"github.com/ONSdigital/dp-import-api/job"
 	"github.com/ONSdigital/dp-import-api/job/testjob"
 	"github.com/ONSdigital/dp-import-api/models"
 	"github.com/ONSdigital/dp-import-api/mongo/testmongo"
 	"github.com/ONSdigital/dp-import-api/url"
-	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 	"testing"
 )


### PR DESCRIPTION
Fix to use errors package from the standard library instead of external package.
