### PR TITLE
Remove logging of entire list response in favor of list length

### DIFF
--- a/api/getjobs.go
+++ b/api/getjobs.go
@@ -53,7 +53,7 @@ func (api *ImportAPI) getJobs(ctx context.Context, filterList []string, auditPar
 		log.ErrorCtx(ctx, errors.WithMessage(err, "getJobs endpoint: failed to retrieve a list of jobs"), logData)
 		return
 	}
-	logData["Jobs"] = jobs
+	logData["number_of_jobs"] = len(jobs)
 
 	b, err = json.Marshal(jobs)
 	if err != nil {


### PR DESCRIPTION
### What

Remove logging of entire list response because frankly it's ridiculous an unnecessary.
Replaced with logging list length, as assurance of the rough size of the response (proof something is being returned)

### How to review

Check log amendment is useful

### Who can review

anyone