### PR TITLE
use new cantabular avro schema, and update Recipe struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.33.6
 	github.com/ONSdigital/dp-healthcheck v1.0.5
-	github.com/ONSdigital/dp-import v1.0.0
+	github.com/ONSdigital/dp-import v1.1.0
 	github.com/ONSdigital/dp-kafka/v2 v2.2.0
 	github.com/ONSdigital/dp-mongodb v1.5.0
 	github.com/ONSdigital/dp-net v1.0.11

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/ONSdigital/dp-api-clients-go v1.33.6 h1:RsVZ7a5Z8tpUpe6ARA2+XmdbG8BAY
 github.com/ONSdigital/dp-api-clients-go v1.33.6/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-healthcheck v1.0.5 h1:DXnohGIqXaLLeYGdaGOhgkZjAbWMNoLAjQ3EgZeMT3M=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
-github.com/ONSdigital/dp-import v1.0.0 h1:cQK3PS6a55nowIekZjf0W+GYU+FIoZ9asm6hDXCsCJk=
-github.com/ONSdigital/dp-import v1.0.0/go.mod h1:WTsFDrvob+eTEj/JIuzUWdwLhHPRf3KETVDT9fEK+88=
+github.com/ONSdigital/dp-import v1.1.0 h1:6pprHZ/TdEqVD4xjzlsmDyzv3r0XiD97pRQ5B3FsYWg=
+github.com/ONSdigital/dp-import v1.1.0/go.mod h1:WTsFDrvob+eTEj/JIuzUWdwLhHPRf3KETVDT9fEK+88=
 github.com/ONSdigital/dp-kafka/v2 v2.2.0 h1:4s9VfmUxi70WpaRZk/CbxDNGqcJTsNTE9aLaLgcn4n4=
 github.com/ONSdigital/dp-kafka/v2 v2.2.0/go.mod h1:lFw9GGYpW8N6dG7g2wLQgCJL9vpo17RvOzCsdMRCapQ=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=

--- a/importqueue/importqueue.go
+++ b/importqueue/importqueue.go
@@ -51,7 +51,7 @@ func (q *ImportQueue) queueV4(ctx context.Context, job *models.ImportData) error
 		return errors.New("v4 queue (kafka producer) is not available")
 	}
 	if job.InstanceIDs == nil || len(job.InstanceIDs) != 1 || job.UploadedFiles == nil || len(*job.UploadedFiles) != 1 {
-		return errors.New("InstanceIds and uploaded files must be 1")
+		return errors.New("InstanceIds and uploaded files must have length 1")
 	}
 
 	inputFileAvailableEvent := events.InputFileAvailable{
@@ -77,10 +77,11 @@ func (q *ImportQueue) queueCantabular(ctx context.Context, job *models.ImportDat
 		return errors.New("cantabular queue (kafka producer) is not available")
 	}
 	if job.InstanceIDs == nil || len(job.InstanceIDs) != 1 {
-		return errors.New("InstanceIds must be 1")
+		return errors.New("InstanceIds must have length 1")
 	}
 
 	event := events.CantabularDatasetInstanceStarted{
+		RecipeID:       job.Recipe,
 		JobID:          job.JobID,
 		InstanceID:     job.InstanceIDs[0],
 		CantabularType: job.Format,

--- a/importqueue/importqueue_test.go
+++ b/importqueue/importqueue_test.go
@@ -9,13 +9,15 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
+const testRecipeID = "b944be78-f56d-409b-9ebd-ab2b77ffe187"
+
 func TestQueueV4File(t *testing.T) {
 	ctx := context.Background()
 
 	job := models.ImportData{
 		JobID:         "jobId",
 		InstanceIDs:   []string{"1"},
-		Recipe:        "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+		Recipe:        testRecipeID,
 		Format:        "v4",
 		UploadedFiles: &[]models.UploadedFile{{AliasName: "aliasV4", URL: "s3//aws/000/v4.csv"}}}
 
@@ -42,64 +44,64 @@ func TestQueueV4File(t *testing.T) {
 		Convey("Then importing a 'v4' recipe with nil instanceIDs fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs:   nil,
-				Recipe:        "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:        testRecipeID,
 				Format:        "v4",
 				UploadedFiles: &[]models.UploadedFile{{AliasName: "aliasV4", URL: "s3//aws/000/v4.csv"}}})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must have length 1")
 		})
 
 		Convey("Then importing a 'v4' recipe with empty instanceIDs fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs:   []string{},
-				Recipe:        "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:        testRecipeID,
 				Format:        "v4",
 				UploadedFiles: &[]models.UploadedFile{{AliasName: "aliasV4", URL: "s3//aws/000/v4.csv"}}})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must have length 1")
 		})
 
 		Convey("Then importing a 'v4' recipe with multiple instanceIDs fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs:   []string{"1", "2"},
-				Recipe:        "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:        testRecipeID,
 				Format:        "v4",
 				UploadedFiles: &[]models.UploadedFile{{AliasName: "aliasV4", URL: "s3//aws/000/v4.csv"}}})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must have length 1")
 		})
 
 		Convey("Then importing a 'v4' recipe with nil uploadedFiles fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs:   []string{"1"},
-				Recipe:        "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:        testRecipeID,
 				Format:        "v4",
 				UploadedFiles: nil})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must have length 1")
 		})
 
 		Convey("Then importing a 'v4' recipe with empty uploadedFiles fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs:   []string{"1"},
-				Recipe:        "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:        testRecipeID,
 				Format:        "v4",
 				UploadedFiles: &[]models.UploadedFile{}})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must have length 1")
 		})
 
 		Convey("Then importing a 'v4' recipe with multiple uploadedFiles fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs: []string{"1"},
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      "v4",
 				UploadedFiles: &[]models.UploadedFile{
 					{AliasName: "aliasV41", URL: "s3//aws/000/v41.csv"},
 					{AliasName: "aliasV42", URL: "s3//aws/000/v42.csv"},
 				}})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds and uploaded files must have length 1")
 		})
 
 		Convey("Then importing a valid 'v4' recipe sends the expected import event to the v4 queue", func() {
@@ -130,7 +132,7 @@ func TestQueueCantabularFile(t *testing.T) {
 			err := importer.Queue(ctx, &models.ImportData{
 				JobID:       "jobId",
 				InstanceIDs: []string{"InstanceId"},
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      formatCantabularBlob,
 			})
 			So(err, ShouldNotBeNil)
@@ -141,7 +143,7 @@ func TestQueueCantabularFile(t *testing.T) {
 			err := importer.Queue(ctx, &models.ImportData{
 				JobID:       "jobId",
 				InstanceIDs: []string{"InstanceId"},
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      formatCantabularTable,
 			})
 			So(err, ShouldNotBeNil)
@@ -162,62 +164,62 @@ func TestQueueCantabularFile(t *testing.T) {
 		Convey("Then importing a 'cantabular_blob' recipe with nil instanceIDs fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs: nil,
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      formatCantabularBlob})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds must have length 1")
 		})
 
 		Convey("Then importing a 'cantabular_table' recipe with nil instanceIDs fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs: nil,
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      formatCantabularTable})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds must have length 1")
 		})
 
 		Convey("Then importing a 'cantabular_blob' recipe with empty instanceIDs fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs: []string{},
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      formatCantabularBlob})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds must have length 1")
 		})
 
 		Convey("Then importing a 'cantabular_table' recipe with empty instanceIDs fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs: []string{},
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      formatCantabularTable})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds must have length 1")
 		})
 
 		Convey("Then importing a 'cantabular_blob' recipe with multiple instanceIDs fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs: []string{"1", "2"},
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      formatCantabularBlob})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds must have length 1")
 		})
 
 		Convey("Then importing a 'cantabular_table' recipe with multiple instanceIDs fails with the expected error", func() {
 			err := importer.Queue(ctx, &models.ImportData{
 				InstanceIDs: []string{"1", "2"},
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      formatCantabularTable})
 			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "InstanceIds must be 1")
+			So(err.Error(), ShouldEqual, "InstanceIds must have length 1")
 		})
 
 		Convey("Then importing a 'cantabular_blob' recipe sends the expected import event to the cantabular queue", func() {
 			job := &models.ImportData{
 				JobID:       "jobId",
 				InstanceIDs: []string{"InstanceId"},
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      formatCantabularBlob,
 			}
 			err := importer.Queue(ctx, job)
@@ -225,11 +227,12 @@ func TestQueueCantabularFile(t *testing.T) {
 
 			bytes := <-cantabularQueue
 
-			var file events.CantabularDatasetInstanceStarted
-			events.CantabularDatasetInstanceStartedSchema.Unmarshal(bytes, &file)
+			var cantabularEvent events.CantabularDatasetInstanceStarted
+			events.CantabularDatasetInstanceStartedSchema.Unmarshal(bytes, &cantabularEvent)
 
-			So(file, ShouldResemble, events.CantabularDatasetInstanceStarted{
+			So(cantabularEvent, ShouldResemble, events.CantabularDatasetInstanceStarted{
 				JobID:          "jobId",
+				RecipeID:       testRecipeID,
 				InstanceID:     job.InstanceIDs[0],
 				CantabularType: formatCantabularBlob,
 			})
@@ -239,7 +242,7 @@ func TestQueueCantabularFile(t *testing.T) {
 			job := &models.ImportData{
 				JobID:       "jobId",
 				InstanceIDs: []string{"InstanceId"},
-				Recipe:      "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+				Recipe:      testRecipeID,
 				Format:      formatCantabularTable,
 			}
 			err := importer.Queue(ctx, job)
@@ -247,11 +250,12 @@ func TestQueueCantabularFile(t *testing.T) {
 
 			bytes := <-cantabularQueue
 
-			var file events.CantabularDatasetInstanceStarted
-			events.CantabularDatasetInstanceStartedSchema.Unmarshal(bytes, &file)
+			var cantabularEvent events.CantabularDatasetInstanceStarted
+			events.CantabularDatasetInstanceStartedSchema.Unmarshal(bytes, &cantabularEvent)
 
-			So(file, ShouldResemble, events.CantabularDatasetInstanceStarted{
+			So(cantabularEvent, ShouldResemble, events.CantabularDatasetInstanceStarted{
 				JobID:          job.JobID,
+				RecipeID:       testRecipeID,
 				InstanceID:     job.InstanceIDs[0],
 				CantabularType: formatCantabularTable,
 			})
@@ -264,7 +268,7 @@ func TestQueueDefault(t *testing.T) {
 
 	job := models.ImportData{
 		InstanceIDs:   []string{"1"},
-		Recipe:        "b944be78-f56d-409b-9ebd-ab2b77ffe187",
+		Recipe:        testRecipeID,
 		Format:        "other",
 		UploadedFiles: &[]models.UploadedFile{{AliasName: "aliasOther", URL: "s3//aws/000/other.csv"}}}
 

--- a/models/models.go
+++ b/models/models.go
@@ -83,6 +83,12 @@ type Recipe struct {
 	Alias           string           `json:"alias"`
 	Format          string           `json:"format,omitempty"`
 	OutputInstances []RecipeInstance `json:"output_instances"`
+	InputFiles      []file           `json:"files,omitempty"`
+	CantabularBlob  string           `json:"cantabular_blob,omitempty"`
+}
+
+type file struct {
+	Description string `json:"description,omitempty"`
 }
 
 type RecipeInstance struct {


### PR DESCRIPTION
### What

Extra changes required by Cantanbular import (it requires the recipe ID):

- use latest version of `dp-import`, with a cantabular avro schema that includes recipeID
- imporqueue adds the recipeID field when handling a Cantabular import job
- updated unit tests accordingly
- updated Reicep struct, with missing fields

### How to review

- Make sure unit tests pass
- Make sure code changes make sense

### Who can review

Anyone
