### PR TITLE
Add processed instances counter

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -3,8 +3,9 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/ONSdigital/dp-import-api/config"
 	"net/http"
+
+	"github.com/ONSdigital/dp-import-api/config"
 
 	errs "github.com/ONSdigital/dp-import-api/apierrors"
 	"github.com/ONSdigital/dp-import-api/datastore"
@@ -17,7 +18,8 @@ import (
 //go:generate moq -out testapi/job_service.go -pkg testapi . JobService
 
 const (
-	jobIDKey = "job_id"
+	jobIDKey      = "job_id"
+	instanceIDKey = "instance_id"
 )
 
 // ImportAPI is a restful API used to manage importing datasets to be published
@@ -56,6 +58,7 @@ func Setup(router *mux.Router,
 	api.router.Path("/jobs/{id}").Methods("GET").HandlerFunc(handlers.CheckIdentity(api.getJobHandler))
 	api.router.Path("/jobs/{id}").Methods("PUT").HandlerFunc(handlers.CheckIdentity(api.updateJobHandler))
 	api.router.Path("/jobs/{id}/files").Methods("PUT").HandlerFunc(handlers.CheckIdentity(api.addUploadedFileHandler))
+	api.router.Path("/jobs/{id}/processed/{instance_id}").Methods("PUT").HandlerFunc(handlers.CheckIdentity(api.increaseProcessedInstanceHandler))
 	return api
 }
 

--- a/api/increase_processed.go
+++ b/api/increase_processed.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	errs "github.com/ONSdigital/dp-import-api/apierrors"
+	dphttp "github.com/ONSdigital/dp-net/http"
+	"github.com/ONSdigital/log.go/log"
+	"github.com/gorilla/mux"
+)
+
+func (api *ImportAPI) increaseProcessedInstanceHandler(w http.ResponseWriter, r *http.Request) {
+
+	defer dphttp.DrainBody(r)
+
+	ctx := r.Context()
+	vars := mux.Vars(r)
+	jobID := vars["id"]
+	instanceID := vars["instance_id"]
+	logData := log.Data{jobIDKey: jobID, instanceIDKey: instanceID}
+
+	// TODO get lock
+
+	// Get import job from DB
+	job, err := api.dataStore.GetJob(jobID)
+	if err != nil {
+		handleErr(ctx, w, err, logData)
+		return
+	}
+
+	// Increase the count for the provided instance
+	found := false
+	for i, instance := range job.Processed {
+		if instance.ID == instanceID {
+			job.Processed[i].ProcessedCount++
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		handleErr(ctx, w, errs.ErrInvalidInstanceID, logData)
+		return
+	}
+
+	// Update the processedInstance
+	if err := api.dataStore.UpdateProcessedInstance(jobID, job.Processed); err != nil {
+		handleErr(ctx, w, err, logData)
+		return
+	}
+	log.Event(ctx, "job update completed successfully", log.INFO, logData)
+
+	// marshal full Processed array as a response
+	b, err := json.Marshal(job.Processed)
+	if err != nil {
+		handleErr(ctx, w, err, logData)
+		return
+	}
+
+	writeResponse(ctx, w, http.StatusOK, b, "increaseProcessedInstanceHandler", logData)
+	log.Event(ctx, "created new import job", log.INFO, logData)
+}

--- a/api/increase_processed_test.go
+++ b/api/increase_processed_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ONSdigital/dp-import-api/api/testapi"
+	"github.com/ONSdigital/dp-import-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestIncreaseProcessedInstanceHandler(t *testing.T) {
+
+	t.Parallel()
+
+	Convey("Given a request to increase the processed count for an instance", t, func() {
+		w := httptest.NewRecorder()
+		r, err := testapi.CreateRequestWithAuth(http.MethodPut, "http://localhost:21800/jobs/34534543543/processed/54321", nil)
+		So(err, ShouldBeNil)
+
+		Convey("When the update is successful", func() {
+			api := SetupAPIWith(nil, nil)
+			api.router.ServeHTTP(w, r)
+
+			Convey("Then the returned status code 200 OK, with the expected body", func() {
+				So(w.Code, ShouldEqual, http.StatusOK)
+				validateBody(w.Body, []models.ProcessedInstances{
+					{
+						ID:             "54321",
+						RequiredCount:  5,
+						ProcessedCount: 1,
+					},
+				})
+			})
+		})
+
+		Convey("When the datastore returns an InternalError", func() {
+			api := SetupAPIWith(&testapi.DstoreInternalError, nil)
+			api.router.ServeHTTP(w, r)
+
+			Convey("Then the returned status code 500 Internal Server Error, with the expected body", func() {
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				So(w.Body.String(), ShouldEqual, "internal error\n")
+			})
+		})
+
+		Convey("When the instance does not exist for the import job", func() {
+			r.URL.Path = "/jobs/34534543543/processed/inexistent"
+			api := SetupAPIWith(nil, nil)
+			api.router.ServeHTTP(w, r)
+
+			Convey("Then the returned status code 400 Bad request, with the expected body", func() {
+				So(w.Code, ShouldEqual, http.StatusBadRequest)
+				So(w.Body.String(), ShouldEqual, "the instance id was not found in the provided job\n")
+			})
+		})
+	})
+}
+
+func validateBody(b *bytes.Buffer, expected []models.ProcessedInstances) {
+	actual := []models.ProcessedInstances{}
+	err := json.Unmarshal(b.Bytes(), &actual)
+	So(err, ShouldBeNil)
+	So(actual, ShouldResemble, expected)
+}

--- a/api/increase_processed_test.go
+++ b/api/increase_processed_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ONSdigital/dp-import-api/api/testapi"
 	"github.com/ONSdigital/dp-import-api/models"
+	testmongo "github.com/ONSdigital/dp-import-api/mongo/testmongo"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -22,7 +23,8 @@ func TestIncreaseProcessedInstanceHandler(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("When the update is successful", func() {
-			api := SetupAPIWith(nil, nil)
+			ds := &testmongo.DataStorer{}
+			api := SetupAPIWith(ds, nil)
 			api.router.ServeHTTP(w, r)
 
 			Convey("Then the returned status code 200 OK, with the expected body", func() {
@@ -34,6 +36,11 @@ func TestIncreaseProcessedInstanceHandler(t *testing.T) {
 						ProcessedCount: 1,
 					},
 				})
+			})
+
+			Convey("Then the datastore has been locked, but is no longer locked", func() {
+				So(ds.HasBeenLocked, ShouldBeTrue)
+				So(ds.IsLocked, ShouldBeFalse)
 			})
 		})
 

--- a/apierrors/utils.go
+++ b/apierrors/utils.go
@@ -15,6 +15,7 @@ var (
 	ErrInternalServer            = errors.New("internal error")
 	ErrInvalidState              = errors.New("invalid state")
 	ErrInvalidUploadedFileObject = errors.New("invalid json object received, alias_name and url are required")
+	ErrInvalidInstanceID         = errors.New("the instance id was not found in the provided job")
 	ErrJobNotFound               = errors.New("job not found")
 	ErrMissingProperties         = errors.New("missing properties to create import job")
 	ErrUnauthorised              = errors.New("unauthenticated request")
@@ -31,6 +32,7 @@ var (
 		ErrInvalidPositiveInteger:    true,
 		ErrInvalidState:              true,
 		ErrInvalidUploadedFileObject: true,
+		ErrInvalidInstanceID:         true,
 		ErrMissingProperties:         true,
 	}
 )

--- a/datastore/interface.go
+++ b/datastore/interface.go
@@ -15,6 +15,7 @@ type DataStorer interface {
 	GetJob(jobID string) (*models.Job, error)
 	GetJobs(ctx context.Context, filters []string, offset int, limit int) (*models.JobResults, error)
 	UpdateJob(jobID string, update *models.Job) error
+	UpdateProcessedInstance(id string, procInstances []models.ProcessedInstances) error
 	AddUploadedFile(jobID string, message *models.UploadedFile) error
 	Close(context.Context) error
 	Checker(context.Context, *healthcheck.CheckState) error

--- a/datastore/interface.go
+++ b/datastore/interface.go
@@ -19,4 +19,6 @@ type DataStorer interface {
 	AddUploadedFile(jobID string, message *models.UploadedFile) error
 	Close(context.Context) error
 	Checker(context.Context, *healthcheck.CheckState) error
+	AcquireInstanceLock(ctx context.Context, jobID string) (lockID string, err error)
+	UnlockInstance(lockID string) error
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/ONSdigital/dp-net v1.0.12
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/Shopify/sarama v1.28.0 // indirect
-	github.com/globalsign/mgo v0.0.0-20190517090918-73267e130ca1
+	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/gopherjs/gopherjs v0.0.0-20191106031601-ce3c9ade29de // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/justinas/alice v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -51,11 +51,11 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/frankban/quicktest v1.10.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
+github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
-github.com/globalsign/mgo v0.0.0-20190517090918-73267e130ca1 h1:DQs0vsFrJDNGZovxiwBtuUaL0SLrQeNHkHpsIbi7w8U=
-github.com/globalsign/mgo v0.0.0-20190517090918-73267e130ca1/go.mod h1:OQBK0ebL25cW31topLSUPIWIrSesue7+zTa/haAXccQ=
 github.com/go-avro/avro v0.0.0-20171219232920-444163702c11 h1:yswqe8UdKNWn4kjh1YTaAbvOSPeg95xhW7h4qeICL5E=
 github.com/go-avro/avro v0.0.0-20171219232920-444163702c11/go.mod h1:kxj6THYP0dmFPk4Z+bijIAhJoGgeBfyOKXMduhvdJPA=
+github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -99,7 +99,6 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.7 h1:0hzRabrMN4tSTvMfnL3SCv1ZGeAP23ynzodBgaHeMeg=
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -115,6 +114,7 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mongo-go/testdb v0.0.0-20190724200850-a72a12eee610 h1:tNI2PtIri0WEQONCJnhrOquQTZDfd2worapaCSUKES0=
 github.com/mongo-go/testdb v0.0.0-20190724200850-a72a12eee610/go.mod h1:xyZcxcSxyRLfj4CDZzyycsGRcwfpY07ncmD2keFr548=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -134,6 +134,7 @@ github.com/smartystreets/assertions v1.0.2-0.20190801024132-8df9578143a5 h1:RXbZ
 github.com/smartystreets/assertions v1.0.2-0.20190801024132-8df9578143a5/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/square/mongo-lock v0.0.0-20191001051310-282c90e422d0 h1:Ae3eHg4QrqbpLdF/Y6jeREKvgqlgrftOglYY4RHdv9s=
 github.com/square/mongo-lock v0.0.0-20191001051310-282c90e422d0/go.mod h1:wR5++/O5fpa0UtI+9T8gKIi5jjl10va/EIEMRySqic4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -149,7 +150,6 @@ golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -187,7 +187,6 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183 h1:PGIdqvwfpMUyUP+QAlAnKTSWQ671SmYjoou2/5j7HXk=
 gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183/go.mod h1:FvqrFXt+jCsyQibeRv4xxEJBL5iG2DDW5aeJwzDiq4A=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
@@ -196,7 +195,6 @@ gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eR
 gopkg.in/jcmturner/goidentity.v3 v3.0.0/go.mod h1:oG2kH0IvSYNIu80dVAyu/yoefjq1mNfM5bm88whjWx4=
 gopkg.in/jcmturner/gokrb5.v7 v7.5.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
-gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH1EMZPLyqSMM8JbIavyFACoFNk=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/job/service_test.go
+++ b/job/service_test.go
@@ -24,9 +24,11 @@ var (
 		OutputInstances: []recipe.Instance{
 			{
 				DatasetID: "dataset1",
+				CodeLists: []recipe.CodeList{{ID: "codelist11"}, {ID: "codelist12"}},
 			},
 			{
 				DatasetID: "dataset2",
+				CodeLists: []recipe.CodeList{{ID: "codelist21"}, {ID: "codelist22"}, {ID: "codelist23"}},
 			},
 		},
 	}
@@ -46,7 +48,7 @@ func dummyInstance() *dataset.Instance {
 
 // expectedNewInstance creates an expected NewInstance for the provided jobID and datasetID
 func expectedNewInstance(jobID, datasetID string) *dataset.NewInstance {
-	return &dataset.NewInstance{
+	newInstance := &dataset.NewInstance{
 		Links: &dataset.Links{
 			Dataset: dataset.Link{
 				URL: "http://localhost:22000/datasets/" + datasetID,
@@ -66,6 +68,12 @@ func expectedNewInstance(jobID, datasetID string) *dataset.NewInstance {
 			BuildSearchIndexTasks: []*dataset.BuildSearchIndexTask{},
 		},
 	}
+	if datasetID == "dataset1" {
+		newInstance.Dimensions = []dataset.CodeList{{ID: "codelist11"}, {ID: "codelist12"}}
+	} else if datasetID == "dataset2" {
+		newInstance.Dimensions = []dataset.CodeList{{ID: "codelist21"}, {ID: "codelist22"}, {ID: "codelist23"}}
+	}
+	return newInstance
 }
 
 func TestService_CreateJob(t *testing.T) {

--- a/models/models.go
+++ b/models/models.go
@@ -38,13 +38,14 @@ type JobResults struct {
 
 // Job for importing datasets
 type Job struct {
-	ID              string              `bson:"id,omitempty"               json:"id,omitempty"`
-	RecipeID        string              `bson:"recipe,omitempty"           json:"recipe,omitempty"`
-	State           string              `bson:"state,omitempty"            json:"state,omitempty"`
-	UploadedFiles   *[]UploadedFile     `bson:"files,omitempty"            json:"files,omitempty"`
-	Links           LinksMap            `bson:"links,omitempty"            json:"links,omitempty"`
-	LastUpdated     time.Time           `bson:"last_updated,omitempty"     json:"last_updated,omitempty"`
-	UniqueTimestamp bson.MongoTimestamp `bson:"unique_timestamp,omitempty" json:"-"`
+	ID              string               `bson:"id,omitempty"                  json:"id,omitempty"`
+	RecipeID        string               `bson:"recipe,omitempty"              json:"recipe,omitempty"`
+	State           string               `bson:"state,omitempty"               json:"state,omitempty"`
+	UploadedFiles   *[]UploadedFile      `bson:"files,omitempty"               json:"files,omitempty"`
+	Links           LinksMap             `bson:"links,omitempty"               json:"links,omitempty"`
+	Processed       []ProcessedInstances `bson:"processed_instances,omitempty" json:"processed_instances,omitempty"`
+	LastUpdated     time.Time            `bson:"last_updated,omitempty"        json:"last_updated,omitempty"`
+	UniqueTimestamp bson.MongoTimestamp  `bson:"unique_timestamp,omitempty"    json:"-"`
 }
 
 // LinksMap represents a list of links related to a job resource
@@ -112,6 +113,13 @@ type DataBakerEvent struct {
 type IDLink struct {
 	ID   string `json:"id"`
 	HRef string `json:"href"`
+}
+
+// ProcessedInstances holds the ID and the number of code lists that have been processed during an import process for an instance
+type ProcessedInstances struct {
+	ID             string `bson:"id,omitempty"               json:"id,omitempty"`
+	RequiredCount  int    `bson:"required_count,omitempty"   json:"required_count,omitempty"`
+	ProcessedCount int    `bson:"processed_count,omitempty"  json:"processed_count,omitempty"`
 }
 
 // CreateJob from a json message

--- a/mongo/testmongo/datastore.go
+++ b/mongo/testmongo/datastore.go
@@ -40,7 +40,16 @@ func (ds *DataStorer) GetJob(jobID string) (*models.Job, error) {
 	if ds.NotFound {
 		return &models.Job{}, errs.ErrJobNotFound
 	}
-	return &models.Job{ID: "34534543543"}, nil
+	return &models.Job{
+		ID: "34534543543",
+		Processed: []models.ProcessedInstances{
+			{
+				ID:             "54321",
+				RequiredCount:  5,
+				ProcessedCount: 0,
+			},
+		},
+	}, nil
 }
 
 func (ds *DataStorer) AddInstance(jobID string) (string, error) {
@@ -74,6 +83,16 @@ func (ds *DataStorer) UpdateJobState(string, string) error {
 }
 
 func (ds *DataStorer) AddUploadedFile(jobID string, message *models.UploadedFile) error {
+	if ds.NotFound {
+		return errs.ErrJobNotFound
+	}
+	if ds.InternalError {
+		return InternalError
+	}
+	return nil
+}
+
+func (ds *DataStorer) UpdateProcessedInstance(id string, procInstances []models.ProcessedInstances) (err error) {
 	if ds.NotFound {
 		return errs.ErrJobNotFound
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -45,8 +45,8 @@ type Service struct {
 }
 
 // getMongoDataStore creates a mongoDB connection
-var getMongoDataStore = func(cfg *config.Configuration) (datastore.DataStorer, error) {
-	return mongo.NewDatastore(cfg.MongoDBURL, cfg.MongoDBDatabase, cfg.MongoDBCollection)
+var getMongoDataStore = func(ctx context.Context, cfg *config.Configuration) (datastore.DataStorer, error) {
+	return mongo.NewDatastore(ctx, cfg.MongoDBURL, cfg.MongoDBDatabase, cfg.MongoDBCollection)
 }
 
 // getKafkaProducer creates a new Kafka Producer
@@ -83,7 +83,7 @@ func (svc *Service) Init(ctx context.Context, cfg *config.Configuration, buildTi
 	svc.cfg = cfg
 
 	// Get mongoDB connection (non-fatal)
-	svc.mongoDataStore, err = getMongoDataStore(svc.cfg)
+	svc.mongoDataStore, err = getMongoDataStore(ctx, svc.cfg)
 	if err != nil {
 		log.Event(ctx, "mongodb datastore error", log.ERROR, log.Error(err))
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -47,7 +47,7 @@ func TestInit(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		datastoreMock := &dsmock.DataStorerMock{}
-		getMongoDataStore = func(cfg *config.Configuration) (datastore.DataStorer, error) {
+		getMongoDataStore = func(ctx context.Context, cfg *config.Configuration) (datastore.DataStorer, error) {
 			return datastoreMock, nil
 		}
 
@@ -75,7 +75,7 @@ func TestInit(t *testing.T) {
 		svc := &Service{}
 
 		Convey("Given that initialising MongoDB returns an error", func() {
-			getMongoDataStore = func(cfg *config.Configuration) (datastore.DataStorer, error) {
+			getMongoDataStore = func(ctx context.Context, cfg *config.Configuration) (datastore.DataStorer, error) {
 				return nil, errMongo
 			}
 


### PR DESCRIPTION

### What

- Added `PUT /jobs/{id}/processed/{instance_id}` endpoint, to increase a count for each instance
- Updated import job model to keep the current count and the total count
- The endpoint acquires a lock so that the read + update can be done without any race condition between callers.
- Unit tested

Trello card: https://trello.com/c/udwByVJC/5187-use-inserted-dimensions-count-instead-of-cantabular-size-to-determine-if-an-import-has-completed

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- I tested this locally with postman, also tested to sleep after acquiring the lock, and the behaviour was as expected.

### Who can review

anyone