### PR TITLE
use latest version of dp-mongodb, which implementes retries on Unlock

### DIFF
--- a/datastore/interface.go
+++ b/datastore/interface.go
@@ -20,5 +20,5 @@ type DataStorer interface {
 	Close(context.Context) error
 	Checker(context.Context, *healthcheck.CheckState) error
 	AcquireInstanceLock(ctx context.Context, jobID string) (lockID string, err error)
-	UnlockInstance(lockID string) error
+	UnlockInstance(lockID string)
 }

--- a/datastore/mock/mongo.go
+++ b/datastore/mock/mongo.go
@@ -55,7 +55,7 @@ var _ datastore.DataStorer = &DataStorerMock{}
 //             GetJobsFunc: func(ctx context.Context, filters []string, offset int, limit int) (*models.JobResults, error) {
 // 	               panic("mock out the GetJobs method")
 //             },
-//             UnlockInstanceFunc: func(lockID string) error {
+//             UnlockInstanceFunc: func(lockID string)  {
 // 	               panic("mock out the UnlockInstance method")
 //             },
 //             UpdateJobFunc: func(jobID string, update *models.Job) error {
@@ -93,7 +93,7 @@ type DataStorerMock struct {
 	GetJobsFunc func(ctx context.Context, filters []string, offset int, limit int) (*models.JobResults, error)
 
 	// UnlockInstanceFunc mocks the UnlockInstance method.
-	UnlockInstanceFunc func(lockID string) error
+	UnlockInstanceFunc func(lockID string)
 
 	// UpdateJobFunc mocks the UpdateJob method.
 	UpdateJobFunc func(jobID string, update *models.Job) error
@@ -414,7 +414,7 @@ func (mock *DataStorerMock) GetJobsCalls() []struct {
 }
 
 // UnlockInstance calls UnlockInstanceFunc.
-func (mock *DataStorerMock) UnlockInstance(lockID string) error {
+func (mock *DataStorerMock) UnlockInstance(lockID string) {
 	if mock.UnlockInstanceFunc == nil {
 		panic("DataStorerMock.UnlockInstanceFunc: method is nil but DataStorer.UnlockInstance was just called")
 	}
@@ -426,7 +426,7 @@ func (mock *DataStorerMock) UnlockInstance(lockID string) error {
 	lockDataStorerMockUnlockInstance.Lock()
 	mock.calls.UnlockInstance = append(mock.calls.UnlockInstance, callInfo)
 	lockDataStorerMockUnlockInstance.Unlock()
-	return mock.UnlockInstanceFunc(lockID)
+	mock.UnlockInstanceFunc(lockID)
 }
 
 // UnlockInstanceCalls gets all the calls that were made to UnlockInstance.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-import v1.1.0
 	github.com/ONSdigital/dp-kafka/v2 v2.2.0
-	github.com/ONSdigital/dp-mongodb v1.5.0
+	github.com/ONSdigital/dp-mongodb v1.7.0
 	github.com/ONSdigital/dp-net v1.0.12
 	github.com/ONSdigital/log.go v1.0.1
 	github.com/Shopify/sarama v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,13 +12,12 @@ github.com/ONSdigital/dp-kafka/v2 v2.2.0 h1:4s9VfmUxi70WpaRZk/CbxDNGqcJTsNTE9aLa
 github.com/ONSdigital/dp-kafka/v2 v2.2.0/go.mod h1:lFw9GGYpW8N6dG7g2wLQgCJL9vpo17RvOzCsdMRCapQ=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
-github.com/ONSdigital/dp-mongodb v1.5.0 h1:Jrqixx0xr9aPSPya0Wce8Ly1zVwB0M6nC3K4umNPfqI=
-github.com/ONSdigital/dp-mongodb v1.5.0/go.mod h1:zm2gWzuqR+aiy2y2NLnfBIafvhKQ0IVPtiClaYyLkmo=
+github.com/ONSdigital/dp-mongodb v1.7.0 h1:PBIfZSsz8mpbNpg53kaGwrOMCg9tWo7X+DzCdaTQPwo=
+github.com/ONSdigital/dp-mongodb v1.7.0/go.mod h1:DMVcvTIuIbm4F/4ww5iMRKq+dFa6QinyXWUaYd+0+bM=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805082802-e518bc287596/go.mod h1:wDVhk2pYosQ1q6PXxuFIRYhYk2XX5+1CeRRnXpSczPY=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805145012-9227a11caddb/go.mod h1:MrSZwDUvp8u1VJEqa+36Gwq4E7/DdceW+BDCvGes6Cs=
 github.com/ONSdigital/dp-net v1.0.5-0.20200805150805-cac050646ab5/go.mod h1:de3LB9tedE0tObBwa12dUOt5rvTW4qQkF5rXtt4b6CE=
 github.com/ONSdigital/dp-net v1.0.7/go.mod h1:1QFzx32FwPKD2lgZI6MtcsUXritsBdJihlzIWDrQ/gc=
-github.com/ONSdigital/dp-net v1.0.9/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
 github.com/ONSdigital/dp-net v1.0.12 h1:Vd06ia1FXKR9uyhzWykQ52b1LTp4N0VOLnrF7KOeP78=
 github.com/ONSdigital/dp-net v1.0.12/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -72,8 +72,8 @@ func (m *Mongo) AcquireInstanceLock(ctx context.Context, jobID string) (lockID s
 
 // UnlockInstance releases an exclusive mongoDB lock for the provided lockId (if it exists)
 // Note: the lock is currently only used to update processed_instances
-func (m *Mongo) UnlockInstance(lockID string) error {
-	return m.lockClient.Unlock(lockID)
+func (m *Mongo) UnlockInstance(lockID string) {
+	m.lockClient.Unlock(lockID)
 }
 
 // GetJobs retrieves all import documents matching filters

--- a/mongo/testmongo/datastore.go
+++ b/mongo/testmongo/datastore.go
@@ -123,10 +123,8 @@ func (m *DataStorer) AcquireInstanceLock(ctx context.Context, jobID string) (loc
 	return testLockID, nil
 }
 
-func (m *DataStorer) UnlockInstance(lockID string) error {
+func (m *DataStorer) UnlockInstance(lockID string) {
 	if lockID == testLockID {
 		m.IsLocked = false
-		return nil
 	}
-	return errors.New("wrongLockID")
 }


### PR DESCRIPTION
### What

Upgraded dp-mongodb dependency to use the Unlock retry mechanism (in v1)

### How to review

- Make sure changes make sense
- Make sure unit tests pass

### Who can review

anyone