### PR TITLE
Fix/dp kafka v2.4.3

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -81,7 +81,7 @@ func Get() (*Configuration, error) {
 		DefaultMaxLimit:            1000,
 		DefaultOffset:              0,
 		KafkaConfig: KafkaConfig{
-			Brokers:                               []string{"localhost:9092"},
+			Brokers:                               []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 			DatabakerImportTopic:                  "data-bake-job-available",
 			InputFileAvailableTopic:               "input-file-available",
 			CantabularDatasetInstanceStartedTopic: "cantabular-dataset-instance-started",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ var expectedConfig = &Configuration{
 	DefaultMaxLimit:            1000,
 	DefaultOffset:              0,
 	KafkaConfig: KafkaConfig{
-		Brokers:                               []string{"localhost:9092"},
+		Brokers:                               []string{"localhost:9092", "localhost:9093", "localhost:9094"},
 		DatabakerImportTopic:                  "data-bake-job-available",
 		InputFileAvailableTopic:               "input-file-available",
 		CantabularDatasetInstanceStartedTopic: "cantabular-dataset-instance-started",

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.1.7-beta
 	github.com/ONSdigital/dp-healthcheck v1.2.1
 	github.com/ONSdigital/dp-import v1.2.1
-	github.com/ONSdigital/dp-kafka/v2 v2.4.1
+	github.com/ONSdigital/dp-kafka/v2 v2.4.3
 	github.com/ONSdigital/dp-mongodb/v3 v3.0.0-beta.5
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/log.go/v2 v2.0.9

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/ONSdigital/dp-healthcheck v1.2.1/go.mod h1:XUhXoDIWPCdletDtpDOoXhmDFc
 github.com/ONSdigital/dp-import v1.2.1 h1:IySfrNsrsWaqFAVgZSaOEaE5StVUJ1TJIZgVAFdBIxk=
 github.com/ONSdigital/dp-import v1.2.1/go.mod h1:WTsFDrvob+eTEj/JIuzUWdwLhHPRf3KETVDT9fEK+88=
 github.com/ONSdigital/dp-kafka/v2 v2.2.0/go.mod h1:lFw9GGYpW8N6dG7g2wLQgCJL9vpo17RvOzCsdMRCapQ=
-github.com/ONSdigital/dp-kafka/v2 v2.4.1 h1:e4nTpfsqb/gRRF3ZgstZ8mEjONvt+QPoWKbZoRg5dU8=
-github.com/ONSdigital/dp-kafka/v2 v2.4.1/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3 h1:Sb5nc4M3RsDMDmclsTqyjTMP6IBD7dRkv3kaIM26LLs=
+github.com/ONSdigital/dp-kafka/v2 v2.4.3/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9 h1:+WXVfTDyWXY1DQRDFSmt1b/ORKk5c7jGiPu7NoeaM/0=
 github.com/ONSdigital/dp-mocking v0.0.0-20190905163309-fee2702ad1b9/go.mod h1:BcIRgitUju//qgNePRBmNjATarTtynAgc0yV29VpLEk=
 github.com/ONSdigital/dp-mongodb-in-memory v1.1.0 h1:EjUU1zpIU1LElhiTMAG7qxy7Rq9+VTUtt3/lyA+K7jI=


### PR DESCRIPTION
### What

- Upgrade `dp-kafka` dependency to v2.4.3 to use the healthcheck fix where kafka producers/consumers will have a `warning` health (instead of `critical`) if enough brokers are available
  - min 2 brokers for producers
  - min 1 broker for consumers
- kafkaAddr match brokers in dp-compose

### How to review

Make sure `dp-kafka` dependency is upgraded

### Who can review

anyone